### PR TITLE
fix: Fix overflow of buttons if text is too large, show ellipsis

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,3 +1,7 @@
+version: "next"
+  date: "2018-01-23"
+  fixes:
+    - "Fix overflow of buttons if text is too large, show ellipsis"
 version: "1.0.0-beta-02"
   date: "2018-01-23"
   fixes:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test-e2e-release: 		## Test release build
 	npm run test:e2e
 .PHONY: test-e2e-release
 
-test-e2e-dev:         			## Test dev build
+test-e2e-dev:					## Test dev build
 	npm run release && \
 	export ENV=dev && \
 	npm run dc-rs && \

--- a/src/lib/less/buttons.less
+++ b/src/lib/less/buttons.less
@@ -20,6 +20,8 @@
 	background-image: none;
 	border: 1px solid transparent;
 	border-radius: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
 	&.full-width {
 		width: ~"calc(100% - 16px)";


### PR DESCRIPTION
Fix overflow of buttons if text is too large, show ellipsis