### PR TITLE
Update extUtils.js

### DIFF
--- a/src/lib/external/sense-extension-utils/extUtils.js
+++ b/src/lib/external/sense-extension-utils/extUtils.js
@@ -50,12 +50,16 @@ define( [
 		}
 	}
 
-	function getBasePath () {
-		var prefix = window.location.pathname.substr( 0, window.location.pathname.toLowerCase().lastIndexOf( "/sense" ) + 1 );
-		var url = window.location.href;
-		url = url.split( "/" );
-		return url[0] + "//" + url[2] + ( ( prefix[prefix.length - 1] === "/" ) ? prefix.substr( 0, prefix.length - 1 ) : prefix );
-	}
+  function getBasePath () {
+
+  var appOptions = qlik.currApp().global.session.options;
+  var url = (appOptions.secure ? "https://" : "http://") 
+          + appOptions.host 
+          + (appOptions.port.length > 0 ? ":" + appOptions.port : "") 
+          + appOptions.prefix.substr( 0, appOptions.prefix.length - 1);
+
+  return url;
+  }
 
 	function getExtensionInfo ( extensionUniqueName ) {
 		var defer = $q.defer();


### PR DESCRIPTION
Extension would not load properly when loading cross-origin because it would try to load the resource from the website's url and not the Qlik server url.

Fixes #[issue number].

### Status
```
[ ] Under development
[ ] Waiting for code review
[ ] Waiting for merge
```
### Information
```
[ ] Contains breaking changes
[ ] Contains new API(s)
[ ] Contains documentation
[ ] Contains test
```
### To-do list
```
[ ] [Fix this thing]
[ ] [Fix another thing]
[ ] ...
```
