### PR TITLE
Navigation relative path

### DIFF
--- a/src/lib/js/helpers.js
+++ b/src/lib/js/helpers.js
@@ -216,7 +216,20 @@ define(['qlik'], function (qlik) {
         return defer.reject('qItems is undefined (listType: ' + Utils.get(['listType'], opts) + ')');
       });
       return defer.promise;
-    }
+    },
+
+    /**
+     * Rturn the VirtualProxy giving the url Path
+     */
+
+    getVP: function (path) {
+      let vPath = path.split("/");
+      if(vPath[3] !== "sense")
+        return (vPath[3]);
+      else
+        return('')
+     }
+
   };
 
   return Utils;

--- a/src/properties.js
+++ b/src/properties.js
@@ -465,6 +465,17 @@ define([
     }
   };
 
+
+  var sameQSServer = {
+    ref: 'props.sameQSServer',
+    label: 'Open in same Qlik Sense Server',
+    type: 'boolean',
+    defaultValue: false,
+    show: function (data) {
+      return data.props.navigationAction === 'openWebsite';
+    }
+  };  
+
   // ****************************************************************************************
   // Action Options
   // ****************************************************************************************
@@ -766,6 +777,7 @@ define([
           storyList: storyList,
           websiteUrl: websiteUrl,
           sameWindow: sameWindow,
+          sameQSServer: sameQSServer,
           appList: appList
         }
       }

--- a/src/swr-sense-navigation.js
+++ b/src/swr-sense-navigation.js
@@ -43,7 +43,7 @@ define(
       snapshot: {canTakeSnapshot: false},
       template: ngTemplate,
       controller: [
-        '$scope', '$element', function ($scope /* , $element */) { // eslint-disable-line no-unused-vars
+        '$scope','$location', '$element', function ($scope ,  $location /* , $element */) { // eslint-disable-line no-unused-vars
 
           var DELAY_ACTIONS = 100;
 
@@ -72,8 +72,16 @@ define(
                 $scope.nextSheet();
                 break;
               case 'openWebsite':
-                var url = $scope.layout.props.websiteUrl; // eslint-disable-line no-case-declarations
+                var url; // eslint-disable-line no-case-declarations
                 var same = $scope.layout.props.sameWindow; // eslint-disable-line no-case-declarations
+                var qs = $scope.layout.props.sameQSServer;
+
+                if(qs)
+                  url =$location.protocol()+"://"+$location.host()+"/"+utils.getVP($location.absUrl())+$scope.layout.props.websiteUrl;
+                else
+                  url = $scope.layout.props.websiteUrl;
+
+
                 if (!utils.isEmpty(url)) {
                   var isIframe = inIframe();
                   var target = '';


### PR DESCRIPTION
Added an option to use a relative path navigation when different users access the same Qlik Sense instance using different DNS / Proxys / Virtual Proxys.
Useful for the document chain when import/export between different systems
